### PR TITLE
Documenting changes needed to make separate minio deployment work

### DIFF
--- a/jx-requirements.yml
+++ b/jx-requirements.yml
@@ -14,6 +14,8 @@ spec:
     gitName: github
     gitServer: https://github.com
     provider: kubernetes
+    # region must be one of the AWS available regions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+    region: us-east-1
     registry: ghcr.io
   environments:
   - key: dev
@@ -29,5 +31,9 @@ spec:
       production: false
   repository: bucketrepo
   secretStorage: local
+  storage:
+  - name: logs
+  # other url formats such as s3://minio-1611088947.minio.svc.cluster.local/jx3-logs and s3://minio-1611088947.minio.svc.cluster.local were previously tried but didn't seem to work
+    url: "s3://jx3-logs?endpoint=minio-1611088947.minio.svc.cluster.local:9000&disableSSL=true&s3ForcePathStyle=true&region=ignored"
   vault: {}
   webhook: lighthouse

--- a/versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
+++ b/versionStream/charts/jx3/jx-build-controller/values.yaml.gotmpl
@@ -16,8 +16,13 @@ log:
 {{- end }}
 
 env:
-{{- if and (eq .Values.jxRequirements.cluster.provider "eks") (hasKey .Values.jxRequirements.cluster "region") }}
+# AWS region needs to be set to use local minio log storage, so region must be set despite .Values.jxRequirements.cluster.provider being set to "kubernetes"
+# if the check for "eks" provider is needed here, adding another else if check for eq provider "kubernetes" and hasKey region should suffice
+{{- if and hasKey .Values.jxRequirements.cluster "region" }}
   AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+  # we have hard-coded the minio keys here because we could not figure out a way to have external secrets populated correctly
+  AWS_ACCESS_KEY_ID: "<minio accessKey here>"
+  AWS_SECRET_ACCESS_KEY: "<minio secretKey here>"
 {{ else if eq .Values.jxRequirements.cluster.provider "aks" }}
   {{ if hasKey .Values.jxRequirements.cluster.azure "storage" }}
     {{ if hasKey .Values.jxRequirements.cluster.azure.storage "storageAccountName" }}

--- a/versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
+++ b/versionStream/charts/jx3/jx-pipelines-visualizer/values.yaml.gotmpl
@@ -24,10 +24,15 @@ ingress:
       "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-s": {}
 {{- end }}
 
-{{- if and (eq .Values.jxRequirements.cluster.provider "eks") (hasKey .Values.jxRequirements.cluster "region") }}
+# AWS region needs to be set to use local minio log storage, so region must be set despite .Values.jxRequirements.cluster.provider being set to "kubernetes"
+# if the check for "eks" provider is needed here, adding another else if check for eq provider "kubernetes" and hasKey region should suffice
+{{- if hasKey .Values.jxRequirements.cluster "region" }}
 pod:
   env:
     AWS_REGION: {{ .Values.jxRequirements.cluster.region }}
+    # we have hard-coded the minio keys here because we could not figure out a way to have external secrets populated correctly
+    AWS_ACCESS_KEY_ID: "<minio accessKey here>"
+    AWS_SECRET_ACCESS_KEY: "<minio secretKey here>"
 {{- else if eq .Values.jxRequirements.cluster.provider "aks" }}
 {{- if and (hasKey .Values.jxRequirements.cluster "azure") (hasKey .Values.jxRequirements.cluster.azure "storage") (hasKey .Values.jxRequirements.cluster.azure.storage "storageAccountName")}}
 pod:


### PR DESCRIPTION
This PR contains the changes that were made to my experimental JX cluster in order to integrate minio log storage. I recognize that this is not the proper channel to submit changes to the version stream, but I wanted to make sure to document these changes here so they could be referenced. As a part of the initial minio integration, a previous colleague of mine also submitted the following PR: https://github.com/jenkins-x-plugins/jx-pipeline/pull/265

Note: minio was deployed separately in my experimental cluster (not packaged as a helm chart in the JX cluster repo)